### PR TITLE
Update Dockerfile to remove helm2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ RUN apk add --update curl make docker gettext net-tools openssl bash && \
 rm -rf /var/cache/apk/*
 
 WORKDIR /tmp/install_dir
-# Install helm 2 with helm2 command
-RUN curl -L https://git.io/get_helm.sh | bash && \
-mv /usr/local/bin/helm /usr/local/bin/helm2
 # Install Helm 3
 RUN curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash 
 # Install kubectl

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ docker client
 
 envsubst 
 
-helm2
-
 helm
 
 kubectl


### PR DESCRIPTION
Helm2 is officially deprecated and won't get any sort of update
also almost all of charts in helm community have migrated to helm3
this PR removes Helm2 installation steps which shaves about 25MB of docker image size